### PR TITLE
[BUGS-3381] Recommend blocking user #1

### DIFF
--- a/src/Check/UsersBlockedNumberOne.php
+++ b/src/Check/UsersBlockedNumberOne.php
@@ -46,7 +46,7 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
    * {@inheritdoc}.
    */
   public function getResultFail() {
-    return $this->t('UID #1 is blocked!');
+    return $this->t('UID #1 is not blocked!');
   }
 
   /**
@@ -58,7 +58,7 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
    * {@inheritdoc}.
    */
   public function getResultPass() {
-    return $this->t('UID #1 not blocked.');
+    return $this->t('UID #1 is blocked.');
   }
 
   /**
@@ -71,7 +71,7 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
    */
   public function getAction() {
     if ($this->score != SiteAuditCheckBase::AUDIT_CHECK_SCORE_PASS) {
-      return $this->t('Unblock UID #1');
+      return $this->t('Block UID #1');
     }
   }
 
@@ -84,9 +84,9 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
     $query->condition('uid', 1);
 
     if (!$query->execute()->fetchField()) {
-      return SiteAuditCheckBase::AUDIT_CHECK_SCORE_FAIL;
+      return SiteAuditCheckBase::AUDIT_CHECK_SCORE_PASS;
     }
-    return SiteAuditCheckBase::AUDIT_CHECK_SCORE_PASS;
+    return SiteAuditCheckBase::AUDIT_CHECK_SCORE_FAIL;
   }
 
 }

--- a/src/Check/UsersBlockedNumberOne.php
+++ b/src/Check/UsersBlockedNumberOne.php
@@ -46,7 +46,7 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
    * {@inheritdoc}.
    */
   public function getResultFail() {
-    return $this->t('UID #1 is not blocked!');
+    return $this->t('UID #1 should be blocked, but is not.');
   }
 
   /**
@@ -58,7 +58,7 @@ class UsersBlockedNumberOne extends SiteAuditCheckBase {
    * {@inheritdoc}.
    */
   public function getResultPass() {
-    return $this->t('UID #1 is blocked.');
+    return $this->t('UID #1 is blocked, as recommended.');
   }
 
   /**

--- a/src/Check/UsersCountBlocked.php
+++ b/src/Check/UsersCountBlocked.php
@@ -82,6 +82,7 @@ class UsersCountBlocked extends SiteAuditCheckBase {
   public function calculateScore() {
     $query = Database::getConnection()->select('users_field_data', 'ufd');
     $query->addExpression('COUNT(*)', 'count');
+    $query->condition('uid', 0, '>');
     $query->condition('status', 0);
 
     $this->registry->count_users_blocked = $query->execute()->fetchField();

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -48,7 +48,7 @@ class UsersTest extends TestCase
         $this->drush('user:block', ['admin']);
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
-        $this->assertEquals('UID #1 is blocked!', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
+        $this->assertEquals('UID #1 is blocked.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
 
         //fail: drush user:unblock admin
         $this->drush('user:unblock', ['admin']);
@@ -65,7 +65,7 @@ class UsersTest extends TestCase
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
         $this->assertEquals('There is one user.', $json['checks']['SiteAuditCheckUsersCountAll']['result']);
-        $this->assertEquals('There is one blocked user.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
+        $this->assertEquals('There are 2 blocked users.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
         $this->assertEquals('administrator: 1', $json['checks']['SiteAuditCheckUsersRolesList']['result']);
         $this->assertEquals('UID #1: admin, email: admin@example.com', $json['checks']['SiteAuditCheckUsersWhoIsNumberOne']['result']);
     }

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -65,7 +65,7 @@ class UsersTest extends TestCase
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
         $this->assertEquals('There is one user.', $json['checks']['SiteAuditCheckUsersCountAll']['result']);
-        $this->assertEquals('There are 2 blocked users.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
+        $this->assertEquals('There is 1 blocked user.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
         $this->assertEquals('administrator: 1', $json['checks']['SiteAuditCheckUsersRolesList']['result']);
         $this->assertEquals('UID #1: admin, email: admin@example.com', $json['checks']['SiteAuditCheckUsersWhoIsNumberOne']['result']);
     }

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -48,13 +48,13 @@ class UsersTest extends TestCase
         $this->drush('user:block', ['admin']);
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
-        $this->assertEquals('UID #1 is blocked.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
+        $this->assertEquals('UID #1 is blocked, as recommended.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
 
         //fail: drush user:unblock admin
         $this->drush('user:unblock', ['admin']);
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
-        $this->assertEquals('UID #1 is not blocked!', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
+        $this->assertEquals('UID #1 should be blocked, but is not.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
 
         //reset
         $this->drush('user:block', ['admin']);

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
  * Users tests
  *
  * SiteAuditCheckUsersBlockedNumberOne:
- *  - pass: drush user:unblock admin
- *  - fail: drush user:block admin
+ *  - pass: drush user:block admin
+ *  - fail: drush user:unblock admin
  *
  * SiteAuditCheckUsersCountAll:
  *  - n/a: This check is informational only, and never fails
@@ -44,20 +44,20 @@ class UsersTest extends TestCase
     public function testUsersBlockedNumberOne()
     {
         //SiteAuditCheckUsersBlockedNumberOne:
-        //pass: drush user:unblock admin
-        $this->drush('user:unblock', ['admin']);
-        $this->drush('audit:users');
-        $json = $this->getOutputFromJSON();
-        $this->assertEquals('UID #1 not blocked.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
-
-        //fail: drush user:block admin
+        //pass: drush user:block admin
         $this->drush('user:block', ['admin']);
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
         $this->assertEquals('UID #1 is blocked!', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
 
-        //reset
+        //fail: drush user:unblock admin
         $this->drush('user:unblock', ['admin']);
+        $this->drush('audit:users');
+        $json = $this->getOutputFromJSON();
+        $this->assertEquals('UID #1 not blocked.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
+
+        //reset
+        $this->drush('user:block', ['admin']);
     }
     public function testUsers()
     {

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -54,7 +54,7 @@ class UsersTest extends TestCase
         $this->drush('user:unblock', ['admin']);
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
-        $this->assertEquals('UID #1 not blocked.', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
+        $this->assertEquals('UID #1 is not blocked!', $json['checks']['SiteAuditCheckUsersBlockedNumberOne']['result']);
 
         //reset
         $this->drush('user:block', ['admin']);

--- a/tests/UsersTest.php
+++ b/tests/UsersTest.php
@@ -65,7 +65,7 @@ class UsersTest extends TestCase
         $this->drush('audit:users');
         $json = $this->getOutputFromJSON();
         $this->assertEquals('There is one user.', $json['checks']['SiteAuditCheckUsersCountAll']['result']);
-        $this->assertEquals('There is 1 blocked user.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
+        $this->assertEquals('There is one blocked user.', $json['checks']['SiteAuditCheckUsersCountBlocked']['result']);
         $this->assertEquals('administrator: 1', $json['checks']['SiteAuditCheckUsersRolesList']['result']);
         $this->assertEquals('UID #1: admin, email: admin@example.com', $json['checks']['SiteAuditCheckUsersWhoIsNumberOne']['result']);
     }


### PR DESCRIPTION
The recommendation for user 1 access has changed. UID 1 should be blocked, not unblocked.

This PR pulls in this update from the upstream Site Audit module: https://www.drupal.org/project/site_audit/issues/3020631

Tests on this should start passing if we merge https://github.com/pantheon-systems/site-audit-tool/pull/15. They are currently failing due to Composer 1 vs 2 issues.