### PR TITLE
[BUGS-9557] Silent fail the auditReport() if Drupal install isn't completed.

### DIFF
--- a/SiteAuditCommands.php
+++ b/SiteAuditCommands.php
@@ -72,6 +72,12 @@ class SiteAuditCommands extends DrushCommands
             'skip' => [],
         ])
     {
+        // abort audit if Drupal install isn't done
+        $task = \Drupal::state()->get("install_task");
+        if($task !==NULL && $task !== 'done') {
+            return;
+        }
+
         $this->init();
 
         $settings_excludes = \Drupal::config('site_audit')->get('opt_out');

--- a/SiteAuditCommands.php
+++ b/SiteAuditCommands.php
@@ -74,7 +74,7 @@ class SiteAuditCommands extends DrushCommands
     {
         // abort audit if Drupal install isn't done
         $task = \Drupal::state()->get("install_task");
-        if($task !==NULL && $task !== 'done') {
+        if($task !== NULL && $task !== 'done') {
             return;
         }
 


### PR DESCRIPTION
BUGS-9557 - The module drupal_cms_installer does not exist after Drupal CMS install