### PR TITLE
BUGS-9557 - Adds a condition that checks if user table exists 

### DIFF
--- a/SiteAuditCommands.php
+++ b/SiteAuditCommands.php
@@ -5,6 +5,7 @@ namespace Drush\Commands\site_audit_tool;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFieldsWithMetadata;
+use Drupal\Core\Database\Database
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
 use SiteAudit\ChecksRegistry;
@@ -75,6 +76,22 @@ class SiteAuditCommands extends DrushCommands
         // abort audit if Drupal install isn't done
         $task = \Drupal::state()->get("install_task");
         if($task !== NULL && $task !== 'done') {
+            return;
+        }
+
+        // and check if the users table exist
+        try {
+            $connection = \Drupal\Core\Database\Database::getConnection();
+            $exists = (bool) $connection->select('users', 'u')
+            ->fields('u', ['uid'])
+            ->range(0,1)
+            ->execute()
+            ->fetchField();
+
+            if (!$exists) {
+                return;
+            }
+        } catch (\Exception $e) {
             return;
         }
 


### PR DESCRIPTION
Adds a condition that checks if the user table exists to end auditReport() if the Drupal Install isn't completed