### PR TITLE
BUGS-9557 - Checks DB before auditReport starts

### DIFF
--- a/SiteAuditCommands.php
+++ b/SiteAuditCommands.php
@@ -5,6 +5,7 @@ namespace Drush\Commands\site_audit_tool;
 use Consolidation\AnnotatedCommand\CommandData;
 use Consolidation\OutputFormatters\StructuredData\PropertyList;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFieldsWithMetadata;
+use Drupal\Core\Database\Database;
 use Drush\Commands\DrushCommands;
 use Drush\Exceptions\UserAbortException;
 use SiteAudit\ChecksRegistry;
@@ -75,6 +76,22 @@ class SiteAuditCommands extends DrushCommands
         // abort audit if Drupal install isn't done
         $task = \Drupal::state()->get("install_task");
         if($task !== NULL && $task !== 'done') {
+            return;
+        }
+
+        // and check if the users table exists
+        try {
+            $connection = \Drupal\Core\Database\Database::getConnection();
+            $exists = (bool) $connection->select('users', 'u')
+            ->fields('u', ['uid'])
+            ->range(0,1)
+            ->execute()
+            ->fetchField();
+
+            if (!$exists) {
+                return;
+            }
+        } catch (\Exception $e) {
             return;
         }
 

--- a/SiteAuditCommands.php
+++ b/SiteAuditCommands.php
@@ -73,12 +73,6 @@ class SiteAuditCommands extends DrushCommands
             'skip' => [],
         ])
     {
-        // abort audit if Drupal install isn't done
-        $task = \Drupal::state()->get("install_task");
-        if($task !== NULL && $task !== 'done') {
-            return;
-        }
-
         // and check if the users table exists
         try {
             $connection = \Drupal\Core\Database\Database::getConnection();
@@ -92,6 +86,12 @@ class SiteAuditCommands extends DrushCommands
                 return;
             }
         } catch (\Exception $e) {
+            return;
+        }
+
+        // abort audit if Drupal install isn't done
+        $task = \Drupal::state()->get("install_task");
+        if($task !== NULL && $task !== 'done') {
             return;
         }
 


### PR DESCRIPTION
Adds a condition to check for table users before starting the audit report and silently fails if the Drupal installation isn't complete. 