### PR TITLE
fix: add explicit permissions block to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   TZ: "/usr/share/zoneinfo/America/Los_Angeles"
   TERM: dumb


### PR DESCRIPTION
Resolves CodeQL code scanning alert [actions/missing-workflow-permissions #1](https://github.com/pantheon-systems/site-audit-tool/security/code-scanning/1).

Adds `permissions: contents: read` at the workflow level. The CI job only checks out code and runs tests — no write access to repository contents, pull requests, or any other scope is needed.